### PR TITLE
Fix webhook initialization in BOTanik.py

### DIFF
--- a/BOTanik.py
+++ b/BOTanik.py
@@ -45,6 +45,5 @@ telegram_app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_
 async def webhook(request: Request):
     data = await request.json()
     update = Update.de_json(data, telegram_app.bot)
-    await telegram_app.initialize()
     await telegram_app.process_update(update)
     return {"ok": True}


### PR DESCRIPTION
## Summary
- remove redundant `initialize()` call before processing Telegram webhook

## Testing
- `python -m py_compile BOTanik.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e320a7ec832aad2df57faa3462d3