### PR TITLE
Initialize Telegram Application on FastAPI startup

### DIFF
--- a/BOTanik.py
+++ b/BOTanik.py
@@ -11,6 +11,10 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 # Telegram-приложение
 app = FastAPI()
 telegram_app = Application.builder().token(BOT_TOKEN).build()
+
+@app.on_event("startup")
+async def startup():
+    await telegram_app.initialize()
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 # GPT-обработка текста


### PR DESCRIPTION
## Summary
- initialize the Telegram app once when FastAPI starts

## Testing
- `python -m py_compile BOTanik.py`


------
https://chatgpt.com/codex/tasks/task_e_6878e4e8d878832a948cfc170a8e0096